### PR TITLE
Improve Configuration Management

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -189,14 +189,20 @@ $(info $(space))
 DEVICE ?= $(shell echo $(NRF_MODEL) | tr a-z A-Z)
 
 # Required files to compile
-START_CODE ?= startup_$(NRF_MODEL).s
+START_CODE ?= gcc_startup_$(NRF_MODEL).s
 SYSTEM_FILE ?= system_$(NRF_MODEL).c
 
 BOOTLOADER_REGION_START = $(addprefix 0x, $(shell echo "obase=16; (${FLASH_KB}-18)*1024" | bc ))
 BOOTLOADER_SETTINGS_ADDRESS = $(addprefix 0x, $(shell echo "obase=16; (${FLASH_KB}-2)*1024" | bc))
 
 # Need some common options for interacting with the chip over JTAG
-JLINK_OPTIONS = -device $(NRF_IC) -if swd -speed 1000
+ifeq ($(NRF_MODEL), nrf51)
+  JLINK_OPTIONS = -device $(NRF_IC) -if swd -speed 1000
+# Default to SDK 12 for nrf52
+else ifeq ($(NRF_MODEL), nrf52)
+  JLINK_OPTIONS = -device $(NRF_MODEL) -if swd -speed 1000
+endif
+
 
 # If not set in app makefile, lets optimize for size
 CFLAGS += -Os
@@ -227,7 +233,6 @@ SOURCE_PATHS += $(BASE_DIR)/services/
 SOURCE_PATHS += $(BASE_DIR)/startup/
 
 # Add paths for each SDK version
-ifeq ($(NRF_MODEL), nrf51)
 ifeq ($(SDK_VERSION), 12)
 
 	# Set the path
@@ -267,6 +272,7 @@ ifeq ($(SDK_VERSION), 12)
 	LIBRARY_PATHS += $(wildcard $(SDK_INCLUDE_PATH)drivers_nrf/validation/)
 	LIBRARY_PATHS += $(wildcard $(SDK_INCLUDE_PATH)drivers_ext/*/)
 	LIBRARY_PATHS += $(wildcard $(SDK_INCLUDE_PATH)device/)
+    LIBRARY_PATHS += $(wildcard $(SDK_INCLUDE_PATH)boards/)
 	LIBRARY_PATHS += $(SDK_INCLUDE_PATH)toolchain/gcc/
 	LIBRARY_PATHS += $(SDK_INCLUDE_PATH)toolchain/
 	LIBRARY_PATHS += $(SDK_INCLUDE_PATH)toolchain/cmsis/include/
@@ -277,6 +283,7 @@ ifeq ($(SDK_VERSION), 12)
 	SOURCE_PATHS += $(wildcard $(SDK_SOURCE_PATH)libraries/*/src/)
 	SOURCE_PATHS += $(wildcard $(SDK_SOURCE_PATH)drivers_nrf/*/)
 	SOURCE_PATHS += $(wildcard $(SDK_SOURCE_PATH)drivers_ext/*/)
+	SOURCE_PATHS += $(SDK_INCLUDE_PATH)toolchain/gcc/ # get access to gcc_startup_nrfxx.s
 
 ifdef SERIALIZATION_MODE
 	LIBRARY_PATHS += $(wildcard $(SDK_INCLUDE_PATH)serialization/*/)
@@ -574,7 +581,6 @@ else
 ifdef SOFTDEVICE_MODEL
 CFLAGS += -DSOFTDEVICE_PRESENT
 endif
-endif
 
 ifdef USE_BLE
     LIBRARY_PATHS += $(wildcard $(SDK_INCLUDE_PATH)ble/*/)
@@ -747,7 +753,13 @@ VPATH = $(SOURCE_PATHS)
 
 OUTPUT_PATH ?= _build/
 
-CPUFLAGS = -mthumb -mcpu=cortex-m0 -march=armv6-m
+CPUFLAGS += -mthumb -mabi=aapcs
+ifeq ($(NRF_MODEL), nrf51)
+CPUFLAGS += -mcpu=cortex-m0 -march=armv6-m
+endif
+ifeq ($(NRF_MODEL), nrf52)
+CPUFLAGS += -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+endif
 CFLAGS += -std=gnu99 -c $(CPUFLAGS) -Wall -Wextra -Wno-unused-parameter -Werror=return-type -D$(DEVICE) -D$(BOARD) -D$(NRF_IC_UPPER) -DSDK_VERSION_$(SDK_VERSION) -DSOFTDEVICE_$(SOFTDEVICE_MODEL)
 CFLAGS += -s -ffunction-sections -fdata-sections
 CFLAGS += -D$(shell echo $(SOFTDEVICE_MODEL) | tr a-z A-Z)

--- a/make/Makefile
+++ b/make/Makefile
@@ -91,8 +91,8 @@ endif
 
 # ---- Set hardware memory sizes
 ifneq (,$(filter $(NRF_IC),nrf51422 nrf51802 nrf51822))
-  RAM_KB   ?= 16   # can be also 32
-  FLASH_KB ?= 256  # can be also 128
+  RAM_KB   ?= 16# can be also 32
+  FLASH_KB ?= 256# can be also 128
 else ifeq ($(NRF_IC), nrf52832)
   RAM_KB   ?= 64
   FLASH_KB ?= 512
@@ -619,7 +619,7 @@ endif # SDK 10
 
 
 ifeq ($(SDK_VERSION), 9)
-
+	
 	# Set the path
 	SDK_PATH ?= $(BASE_DIR)/sdk/nrf51_sdk_9.0.0/
 

--- a/make/Makefile
+++ b/make/Makefile
@@ -16,11 +16,12 @@
 ##   - SOFTDEVICE         : Path to the softdevice to use
 ##   - START_CODE         : .s file to execute first
 ##   - SYSTEM_FILE        : Base nRF .c file.
-##   - NRF_MODEL          : nrf51 | nrf52  : Set by the softdevice used
+##   - NRF_MODEL          : nrf51 | nrf52  : Also set by the NRF_IC used
+##   - NRF_IC             : nrf51422 | nrf51802 | nrf51822 | nrf52832 | nrf52840  
 ##   - BOARD              : Hardware board being used. Will get set as #define.
-##   - RAM_KB             : Size of RAM on chip    : Defaults to 16
-##   - FLASH_KB           : Size of flash on chip  : Defaults to 256
-##   - SDK_VERSION        : Major version number of the SDK to use. Defaults to 10
+##   - RAM_KB             : Size of RAM on chip
+##   - FLASH_KB           : Size of flash on chip
+##   - SDK_VERSION        : Major version number of the SDK to use. Defaults to 10 for nrf51, 12 for nrf52
 ##   - GDB_PORT_NUMBER    : Defaults to 2331
 ##
 ##
@@ -41,106 +42,134 @@ OBJDUMP = $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-objdump
 SIZE    = $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-size
 GDB     = $(TOOLCHAIN_PATH)$(TOOLCHAIN_PREFIX)-gdb
 
-# Guess nRF51 unless otherwise set
-NRF_MODEL ?= nrf51
-NRF_IC    ?= nrf51822
-
 # Set default board
 BOARD ?= BOARD_NULL
 
-# Set hardware memory sizes
-RAM_KB   ?= 16
-FLASH_KB ?= 256
+# TODO: Guess NRF_MODEL from famous BOARD
 
-# Default to SDK 10
-SDK_VERSION ?= 10
+
+# ---- Guess/Check NRF_MODEL from NRF_IC (if NRF_IC defined)
+ifdef NRF_IC
+  #if NRF_IC == nrf51422 or nrf51802 or nrf51822
+  ifneq (,$(filter $(NRF_IC),nrf51422 nrf51802 nrf51822))
+    ifdef NRF_MODEL
+      ifneq ($(NRF_MODEL), nrf51)
+        $(error NRF_MODEL $(NRF_MODEL) is not valid for NRF_IC $(NRF_IC))
+      endif
+    endif
+    NRF_MODEL = nrf51
+  #else if NRF_IC == nrf52832 or nrf52840
+  else ifneq (,$(filter $(NRF_IC),nrf52832 nrf52840))
+    ifdef NRF_MODEL
+      ifneq ($(NRF_MODEL), nrf52)
+        $(error NRF_MODEL $(NRF_MODEL) is not valid for NRF_IC $(NRF_IC))
+      endif
+    endif
+    NRF_MODEL = nrf52
+  endif
+endif
+
+# ---- Force NRF_MODEL for OLD SDK
+ifneq (,$(filter $(SDK_VERSION),9 10))
+  ifneq ($(NRF_MODEL), nrf51)
+    $(error NRF_MODEL $(NRF_MODEL) is not valid for SDK_VERSION $(SDK_VERSION))
+  endif
+  NRF_MODEL = nrf51
+endif
+
+# ---- NRF_MODEL Default to nrf51
+NRF_MODEL ?= nrf51
+
+# --- NRF_IC: Default to nrf51822 for nrf51
+ifeq ($(NRF_MODEL), nrf51)
+  NRF_IC    ?= nrf51822
+# --- NRF_IC: Default to nrf52832 for nrf52
+else ifeq ($(NRF_MODEL), nrf52)
+  NRF_IC    ?= nrf52832
+endif
+  
+
+# ---- Set hardware memory sizes
+ifneq (,$(filter $(NRF_IC),nrf51422 nrf51802 nrf51822))
+  RAM_KB   ?= 16   # can be also 32
+  FLASH_KB ?= 256  # can be also 128
+else ifeq ($(NRF_IC), nrf52832)
+  RAM_KB   ?= 64
+  FLASH_KB ?= 512
+else ifeq ($(NRF_IC), nrf52840)
+  RAM_KB   ?= 256
+  FLASH_KB ?= 1024
+endif
+
+# ---- Set SDK if not SET
+# Default to SDK 10 for nrf51
+ifeq ($(NRF_MODEL), nrf51)
+  SDK_VERSION ?= 10
+# Default to SDK 12 for nrf52
+else ifeq ($(NRF_MODEL), nrf52)
+  SDK_VERSION ?= 12
+endif
 
 # Set this for using GDB
 GDB_PORT_NUMBER ?= 2331
 
-# Choose a default MCU
-NRF_MODEL = nrf51
 
-# Bisect based on nRF model
-ifeq ($(NRF_MODEL), nrf51)
+#------ Now select SOFTDEVICE version if used (depending SDK version)
+# TODO: Check SoftDevice and NRF_IC/NRF_MODEL compatibility
 
-# Now select SDK version
-# SDK 10
-ifeq ($(SDK_VERSION), 10)
+# SDK 9 or 10
+ifneq (,$(filter $(SDK_VERSION),9 10))
 ifeq ($(SOFTDEVICE_MODEL), s110)
     USE_BLE = 1
     SOFTDEVICE_VERSION ?= 8.0.0
-endif
-
-ifeq ($(SOFTDEVICE_MODEL), s120)
+else ifeq ($(SOFTDEVICE_MODEL), s120)
     USE_BLE = 1
     SOFTDEVICE_VERSION ?= 2.1.0
+else ifeq ($(SOFTDEVICE_MODEL), s130)
+    USE_BLE = 1
+    SOFTDEVICE_VERSION ?= 1.0.0
+else ifeq ($(SOFTDEVICE_MODEL), s210)
+    USE_BLE = 1
+    SOFTDEVICE_VERSION ?= 5.0.0
+else ifeq ($(SOFTDEVICE_MODEL), s310)
+    USE_BLE = 1
+    SOFTDEVICE_VERSION ?= 3.0.0
 endif
 endif
 
 # SDK 11
 ifeq ($(SDK_VERSION), 11)
+ifeq ($(SOFTDEVICE_MODEL), s130)
 	USE_BLE = 1
 	SOFTDEVICE_VERSION ?= 2.0.0
-	SOFTDEVICE_MODEL = s130
+else ifeq ($(SOFTDEVICE_MODEL), s132)
+	USE_BLE = 1
+	SOFTDEVICE_VERSION ?= 2.0.0
+else ifeq ($(SOFTDEVICE_MODEL), s212)
+	USE_BLE = 1
+	SOFTDEVICE_VERSION ?= 0.9.1
+else ifeq ($(SOFTDEVICE_MODEL), s332)
+	USE_BLE = 1
+	SOFTDEVICE_VERSION ?= 0.9.1
+endif
 endif
 
 # SDK 12
 ifeq ($(SDK_VERSION), 12)
+ifeq ($(SOFTDEVICE_MODEL), s130)
 	USE_BLE = 1
 	SOFTDEVICE_VERSION ?= 2.0.1
-	SOFTDEVICE_MODEL = s130
-endif
-
-endif
-
-# nRF52
-ifeq ($(NRF_MODEL), nrf52)
-
-# SDK 11
-ifeq ($(SDK_VERSION), 11)
-	USE_BLE = 1
-    SOFTDEVICE_VERSION ?= 2.0.0-4.alpha
-	SOFTDEVICE_MODEL = s132
-    NRF_IC = nrf52832
-endif
-
-# SDK 12
-ifeq ($(SDK_VERSION), 12)
+else ifeq ($(SOFTDEVICE_MODEL), s132)
 	USE_BLE = 1
 	SOFTDEVICE_VERSION ?= 3.0.0
-	SOFTDEVICE_MODEL = s132
-    NRF_IC = nrf52832
+else ifeq ($(SOFTDEVICE_MODEL), s212)
+	USE_BLE = 1
+	SOFTDEVICE_VERSION ?= 2.0.0
+else ifeq ($(SOFTDEVICE_MODEL), s332)
+	USE_BLE = 1
+	SOFTDEVICE_VERSION ?= 2.0.0
 endif
-
 endif
-
-# # Configure which stacks we need for various softdevices
-# ifeq ($(SOFTDEVICE_MODEL), s110)
-#     USE_BLE = 1
-#     SOFTDEVICE_VERSION ?= 8.0.0
-#     NRF_MODEL = nrf51
-# endif
-
-# ifeq ($(SOFTDEVICE_MODEL), s120)
-#     USE_BLE = 1
-#     SOFTDEVICE_VERSION ?= 2.1.0
-#     NRF_MODEL = nrf51
-# endif
-
-# ifeq ($(SOFTDEVICE_MODEL), s130)
-#     USE_BLE = 1
-#     SOFTDEVICE_VERSION ?= 2.0.1
-#     NRF_MODEL = nrf51
-#     SDK_VERSION = 11
-# endif
-
-# ifeq ($(SOFTDEVICE_MODEL), s132)
-#     USE_BLE = 1
-#     SOFTDEVICE_VERSION ?= 2.0.0-4.alpha
-#     NRF_MODEL = nrf52
-#     NRF_IC    = nrf52832
-# endif
 
 
 

--- a/make/ld/gcc_nrf52_blank_0_64_512.ld
+++ b/make/ld/gcc_nrf52_blank_0_64_512.ld
@@ -1,0 +1,29 @@
+/* Linker script to configure memory regions. */
+/* Similar to official nrf52_xxaa.ld defined for nRF52832 */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x80000 /* 512k */
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 0x10000 /* 64k */
+}
+
+SECTIONS
+{
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+  .pwr_mgmt_data :
+  {
+    PROVIDE(__start_pwr_mgmt_data = .);
+    KEEP(*(.pwr_mgmt_data))
+    PROVIDE(__stop_pwr_mgmt_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf5x_common.ld"

--- a/make/ld/nrf5x_common.ld
+++ b/make/ld/nrf5x_common.ld
@@ -1,0 +1,161 @@
+/* Linker script for Nordic Semiconductor nRF51 devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+
+    .heap (COPY):
+    {
+        __HeapBase = .;
+        __end__ = .;
+        PROVIDE(end = .);
+        KEEP(*(.heap*))
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        KEEP(*(.stack*))
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}


### PR DESCRIPTION
 - Guess NRF_MODEL from NRF_IC is set
 - Force NRF_MODEL for old SDK (9, 10)
 - Default SDK depending NRF_IC
 - Default NRF_IC depending NRF_MODEL
 - Default RAM/FLASH depending NRF_IC
 - Bug: No more force SOFTDEVICE on SDK 11 and 12. (black soft device can not be used with these SDK). Close #22.