### PR TITLE
remove __attribute__((weak)) from headers

### DIFF
--- a/lib/simple_ble.c
+++ b/lib/simple_ble.c
@@ -103,6 +103,24 @@ void assert_nrf_callback(uint16_t line_num, const uint8_t * p_file_name);
 /*******************************************************************************
  *   HANDLERS AND CALLBACKS
  ******************************************************************************/
+
+// Default weak references for callbacks
+//
+// All of these callbacks are optional. By declaring prototypes with weak
+// references here, these will turn into pointes with value 0 (definition of
+// behavoir for weak references with forward declaration but no implementation)
+// rather than link time failures.
+//
+// Run-time code must check that these functions are valid before calling.
+void __attribute__((weak)) ble_evt_connected(ble_evt_t* p_ble_evt);
+void __attribute__((weak)) ble_evt_disconnected(ble_evt_t* p_ble_evt);
+void __attribute__((weak)) ble_evt_write(ble_evt_t* p_ble_evt);
+void __attribute__((weak)) ble_evt_rw_auth(ble_evt_t* p_ble_evt);
+void __attribute__((weak)) ble_evt_user_handler(ble_evt_t* p_ble_evt);
+void __attribute__((weak)) ble_evt_adv_report(ble_evt_t* p_ble_evt);
+void __attribute__((weak)) ble_error(uint32_t error_code);
+
+
 #ifndef SOFTDEVICE_s130 // This function is called app_error_fault_handler in the SDK 11
 void app_error_handler(uint32_t error_code, uint32_t line_num, const uint8_t * p_file_name) {
 #else

--- a/lib/simple_ble.h
+++ b/lib/simple_ble.h
@@ -37,29 +37,29 @@ typedef struct simple_ble_char_s {
  *   FUNCTION PROTOTYPES
  ******************************************************************************/
 // implement for callbacks
-extern void __attribute__((weak)) ble_evt_connected(ble_evt_t* p_ble_evt);
-extern void __attribute__((weak)) ble_evt_disconnected(ble_evt_t* p_ble_evt);
-extern void __attribute__((weak)) ble_evt_write(ble_evt_t* p_ble_evt);
-extern void __attribute__((weak)) ble_evt_rw_auth(ble_evt_t* p_ble_evt);
-extern void __attribute__((weak)) ble_evt_user_handler(ble_evt_t* p_ble_evt);
-extern void __attribute__((weak)) ble_evt_adv_report(ble_evt_t* p_ble_evt);
-extern void __attribute__((weak)) ble_error(uint32_t error_code);
+extern void ble_evt_connected(ble_evt_t* p_ble_evt);
+extern void ble_evt_disconnected(ble_evt_t* p_ble_evt);
+extern void ble_evt_write(ble_evt_t* p_ble_evt);
+extern void ble_evt_rw_auth(ble_evt_t* p_ble_evt);
+extern void ble_evt_user_handler(ble_evt_t* p_ble_evt);
+extern void ble_evt_adv_report(ble_evt_t* p_ble_evt);
+extern void ble_error(uint32_t error_code);
 
 // overwrite to change functionality
-void __attribute__((weak)) ble_stack_init(void);
-void __attribute__((weak)) ble_address_set (void);
-void __attribute__((weak)) gap_params_init(void);
-void __attribute__((weak)) advertising_init(void);
-void __attribute__((weak)) conn_params_init(void);
-void __attribute__((weak)) services_init(void);
+void ble_stack_init(void);
+void ble_address_set (void);
+void gap_params_init(void);
+void advertising_init(void);
+void conn_params_init(void);
+void services_init(void);
 #ifdef ENABLE_DFU
-void __attribute__((weak)) dfu_init (void);
-void __attribute__((weak)) dfu_reset_prepare (void);
+void dfu_init (void);
+void dfu_reset_prepare (void);
 #endif
-void __attribute__((weak)) initialize_app_timer(void);
-void __attribute__((weak)) advertising_start(void);
-void __attribute__((weak)) advertising_stop(void);
-void __attribute__((weak)) power_manage(void);
+void initialize_app_timer(void);
+void advertising_start(void);
+void advertising_stop(void);
+void power_manage(void);
 
 // call to initialize
 simple_ble_app_t* simple_ble_init(const simple_ble_config_t* conf);
@@ -106,10 +106,9 @@ int parse_adata(ble_evt_t * p_ble_evt, uint8_t type, uint8_t * data);
 /*******************************************************************************
  *   GLOBAL CONFIGURATIONS
  *******************************************************************************/
-extern __attribute__((weak)) const int SLAVE_LATENCY;
-extern __attribute__((weak)) const int APP_TIMER_MAX_TIMERS;
-extern __attribute__((weak)) const int CONN_SUP_TIMEOUT;
-extern __attribute__((weak)) const int FIRST_CONN_PARAMS_UPDATE_DELAY;
+extern const int SLAVE_LATENCY;
+extern const int CONN_SUP_TIMEOUT;
+extern const int FIRST_CONN_PARAMS_UPDATE_DELAY;
 
 /*******************************************************************************
  *   DEFINES


### PR DESCRIPTION
Weak attributes should only go on the symbols you _actually_ want
to mark as weak, i.e. those in the C sources.

By including this in the headers, you actually cause _every_ definition
of these symbols to be weak, in which case the linker just picks one.

This was likely working without anyone noticing because people generally
write the link rules `ld mystuff.o libnrf.a`, which means the linker
sees your symbol first and happens to choose that one, but that's just
luck really.