### PR TITLE
tiny trick to get Windows builds from within msys/mingw working

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -863,7 +863,8 @@ endif
 
 rebuild: clean all
 
-ifeq ($(OS),Windows_NT)
+# if using mingw/msys, this test will fail and you will correctly get the posix Makefile
+ifeq ($(OS)$(MSYSTEM),Windows_NT)
 include $(BASE_DIR)/make/Makefile.windows
 else
 include $(BASE_DIR)/make/Makefile.posix


### PR DESCRIPTION
When trying to build from within msys the Makefile would crash because it is correctly detecting Windows, but incorrectly trying to use the command.com version of the Makefile.

I found that msys/mingw sets the ```$(MSYSTEM)``` environment variable. Checking for this alongside the ```$(OS)``` environment variable allows the Windows build to work both from command.com and from within msys/mingw.