### PR TITLE
add gzll support under SDK14, add linker scripts for no-softdevice 52810 and 52832

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -899,6 +899,11 @@ ifdef USE_GZP
     APPLICATION_SRCS += nrf_gzp_host_nrf5x.c
 endif
 
+ifdef USE_GZLL
+    LIBRARY_PATHS += $(SDK_INCLUDE_PATH)proprietary_rf/gzll
+    LIBS += $(SDK_INCLUDE_PATH)proprietary_rf/gzll/gcc/gzll_nrf51_sd_resources_gcc.a
+endif
+
 ifdef USE_ESB
     SOURCE_PATHS += $(SDK_SOURCE_PATH)proprietary_rf/esb
     APPLICATION_SRCS += nrf_esb.c

--- a/make/Makefile
+++ b/make/Makefile
@@ -109,6 +109,9 @@ else ifeq ($(NRF_IC), nrf52832)
 else ifeq ($(NRF_IC), nrf52840_xxaa)
   RAM_KB   ?= 256
   FLASH_KB ?= 1024
+else ifeq ($(NRF_IC), nrf52810)
+  RAM_KB   ?= 24
+  FLASH_KB ?= 192
 endif
 
 # ---- Set SDK if not SET
@@ -901,7 +904,7 @@ endif
 
 ifdef USE_GZLL
     LIBRARY_PATHS += $(SDK_INCLUDE_PATH)proprietary_rf/gzll
-    LIBS += $(SDK_INCLUDE_PATH)proprietary_rf/gzll/gcc/gzll_nrf51_sd_resources_gcc.a
+    LIBS += $(SDK_INCLUDE_PATH)proprietary_rf/gzll/gcc/gzll_nrf52_sd_resources_gcc.a
 endif
 
 ifdef USE_ESB
@@ -1148,8 +1151,8 @@ OUTPUT_PATH ?= _build/
 
 ifeq ($(NRF_MODEL), nrf51)
   CPUFLAGS = -mthumb -mcpu=cortex-m0 -march=armv6-m
-else ifneq (,$(filter $(NRF_IC),nrf52832 nrf52840_xxaa))
-  CPUFLAGS = -mthumb -mcpu=cortex-m4 -march=armv7e-m
+else ifneq (,$(filter $(NRF_IC),nrf52810 nrf52832 nrf52840_xxaa))
+  CPUFLAGS = -mthumb -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=hard -mfpu=fpv4-sp-d16
 endif
 
 CFLAGS += -std=gnu99 -c $(CPUFLAGS) -Wall -Wextra -Wno-unused-parameter -Werror=return-type -D$(DEVICE) -D$(BOARD) -D$(NRF_IC_UPPER) -DSDK_VERSION_$(SDK_VERSION) -DSOFTDEVICE_$(SOFTDEVICE_MODEL)

--- a/make/ld/gcc_nrf52_blank_0_24_192.ld
+++ b/make/ld/gcc_nrf52_blank_0_24_192.ld
@@ -1,0 +1,18 @@
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x0, LENGTH = 192K
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 24K
+}
+
+SECTIONS
+{
+  .fs_data_out ALIGN(4):
+  {
+    PROVIDE( __start_fs_data = .);
+    KEEP(*(fs_data))
+    PROVIDE( __stop_fs_data = .);
+  } = 0
+}
+
+INCLUDE "gcc_nrf52_common.ld"

--- a/make/ld/gcc_nrf52_blank_0_64_512.ld
+++ b/make/ld/gcc_nrf52_blank_0_64_512.ld
@@ -1,0 +1,18 @@
+/* Linker script to configure memory regions. */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x0, LENGTH = 512K
+  RAM (rwx) :  ORIGIN = 0x20000000, LENGTH = 64K
+}
+
+SECTIONS
+{
+  .fs_data_out ALIGN(4):
+  {
+    PROVIDE( __start_fs_data = .);
+    KEEP(*(fs_data))
+    PROVIDE( __stop_fs_data = .);
+  } = 0
+}
+
+INCLUDE "gcc_nrf52_common.ld"


### PR DESCRIPTION
Very small PR, just adds in the USE_GZLL check like I did in SDK12.