### PR TITLE
Support for nRF52 compilation

### DIFF
--- a/apps/full_adv/Makefile
+++ b/apps/full_adv/Makefile
@@ -11,13 +11,30 @@ APPLICATION_SRCS += app_util_platform.c
 APPLICATION_SRCS += nrf_drv_common.c
 APPLICATION_SRCS += nrf_delay.c
 APPLICATION_SRCS += led.c
+APPLICATION_SRCS += app_error.c
+APPLICATION_SRCS += app_error_weak.c
 
 APPLICATION_SRCS += simple_ble.c
 APPLICATION_SRCS += simple_adv.c
 
-SOFTDEVICE_MODEL = s110
+USE_NRF52 := $(filter nrf52,$(MAKECMDGOALS))
 
-LIBRARY_PATHS += ../../include
+# Compile for nrf51 by default
+SOFTDEVICE_MODEL = s130
+SDK_VERSION = 11
+NRF_MODEL = nrf51
+
+ifeq ($(USE_NRF52), nrf52)
+SOFTDEVICE_MODEL = s132
+SDK_VERSION = 11
+NRF_MODEL = nrf52
+endif
+
+# Use "make nrf52" to compile for nrf52 platform
+nrf52: clean all
+
+LIBRARY_PATHS += .
+#./../include
 SOURCE_PATHS += ../../src
 
 NRF_BASE_PATH ?= ../..

--- a/apps/full_adv/README.md
+++ b/apps/full_adv/README.md
@@ -3,3 +3,7 @@ Full Advertisement
 
 Sends an advertisement with a full payload (taken by a long name)
 
+This example will compile for both nRF51 and nRF52 platforms
+
+You can select the nRF52 platform by issuing `make nrf52`
+

--- a/apps/full_adv/nrf_drv_config.h
+++ b/apps/full_adv/nrf_drv_config.h
@@ -1,0 +1,464 @@
+/* Copyright (c) 2015 Nordic Semiconductor. All Rights Reserved.
+ *
+ * The information contained herein is property of Nordic Semiconductor ASA.
+ * Terms and conditions of usage are described in detail in NORDIC
+ * SEMICONDUCTOR STANDARD SOFTWARE LICENSE AGREEMENT.
+ *
+ * Licensees are granted free, non-transferable use of the information. NO
+ * WARRANTY of ANY KIND is provided. This heading must NOT be removed from
+ * the file.
+ *
+ */
+
+#ifndef NRF_DRV_CONFIG_H
+#define NRF_DRV_CONFIG_H
+
+/**
+ * Provide a non-zero value here in applications that need to use several
+ * peripherals with the same ID that are sharing certain resources
+ * (for example, SPI0 and TWI0). Obviously, such peripherals cannot be used
+ * simultaneously. Therefore, this definition allows to initialize the driver
+ * for another peripheral from a given group only after the previously used one
+ * is uninitialized. Normally, this is not possible, because interrupt handlers
+ * are implemented in individual drivers.
+ * This functionality requires a more complicated interrupt handling and driver
+ * initialization, hence it is not always desirable to use it.
+ */
+#define PERIPHERAL_RESOURCE_SHARING_ENABLED  0
+
+/* CLOCK */
+#define CLOCK_ENABLED 0
+
+#if (CLOCK_ENABLED == 1)
+#define CLOCK_CONFIG_XTAL_FREQ          NRF_CLOCK_XTALFREQ_Default
+#define CLOCK_CONFIG_LF_SRC             NRF_CLOCK_LFCLK_Xtal
+#define CLOCK_CONFIG_IRQ_PRIORITY       APP_IRQ_PRIORITY_LOW
+#endif
+
+/* GPIOTE */
+#define GPIOTE_ENABLED 0
+
+#if (GPIOTE_ENABLED == 1)
+#define GPIOTE_CONFIG_USE_SWI_EGU false
+#define GPIOTE_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+#define GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS 1
+#endif
+
+/* TIMER */
+#define TIMER0_ENABLED 0
+
+#if (TIMER0_ENABLED == 1)
+#define TIMER0_CONFIG_FREQUENCY    NRF_TIMER_FREQ_16MHz
+#define TIMER0_CONFIG_MODE         TIMER_MODE_MODE_Timer
+#define TIMER0_CONFIG_BIT_WIDTH    TIMER_BITMODE_BITMODE_32Bit
+#define TIMER0_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+#define TIMER0_INSTANCE_INDEX      0
+#endif
+
+#define TIMER1_ENABLED 0
+
+#if (TIMER1_ENABLED == 1)
+#define TIMER1_CONFIG_FREQUENCY    NRF_TIMER_FREQ_16MHz
+#define TIMER1_CONFIG_MODE         TIMER_MODE_MODE_Timer
+#define TIMER1_CONFIG_BIT_WIDTH    TIMER_BITMODE_BITMODE_16Bit
+#define TIMER1_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+#define TIMER1_INSTANCE_INDEX      (TIMER0_ENABLED)
+#endif
+ 
+#define TIMER2_ENABLED 0
+
+#if (TIMER2_ENABLED == 1)
+#define TIMER2_CONFIG_FREQUENCY    NRF_TIMER_FREQ_16MHz
+#define TIMER2_CONFIG_MODE         TIMER_MODE_MODE_Timer
+#define TIMER2_CONFIG_BIT_WIDTH    TIMER_BITMODE_BITMODE_16Bit
+#define TIMER2_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+#define TIMER2_INSTANCE_INDEX      (TIMER1_ENABLED+TIMER0_ENABLED)
+#endif
+
+#define TIMER3_ENABLED 0
+
+#if (TIMER3_ENABLED == 1)
+#define TIMER3_CONFIG_FREQUENCY    NRF_TIMER_FREQ_16MHz
+#define TIMER3_CONFIG_MODE         TIMER_MODE_MODE_Timer
+#define TIMER3_CONFIG_BIT_WIDTH    TIMER_BITMODE_BITMODE_16Bit
+#define TIMER3_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+#define TIMER3_INSTANCE_INDEX      (TIMER2_ENABLED+TIMER1_ENABLED+TIMER0_ENABLED)
+#endif
+
+#define TIMER4_ENABLED 0
+
+#if (TIMER4_ENABLED == 1)
+#define TIMER4_CONFIG_FREQUENCY    NRF_TIMER_FREQ_16MHz
+#define TIMER4_CONFIG_MODE         TIMER_MODE_MODE_Timer
+#define TIMER4_CONFIG_BIT_WIDTH    TIMER_BITMODE_BITMODE_16Bit
+#define TIMER4_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+#define TIMER4_INSTANCE_INDEX      (TIMER3_ENABLED+TIMER2_ENABLED+TIMER1_ENABLED+TIMER0_ENABLED)
+#endif
+
+
+#define TIMER_COUNT (TIMER0_ENABLED + TIMER1_ENABLED + TIMER2_ENABLED + TIMER3_ENABLED + TIMER4_ENABLED)
+
+/* RTC */
+#define RTC0_ENABLED 0
+
+#if (RTC0_ENABLED == 1)
+#define RTC0_CONFIG_FREQUENCY    32678
+#define RTC0_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+#define RTC0_CONFIG_RELIABLE     false
+
+#define RTC0_INSTANCE_INDEX      0
+#endif
+
+#define RTC1_ENABLED 0
+
+#if (RTC1_ENABLED == 1)
+#define RTC1_CONFIG_FREQUENCY    32768
+#define RTC1_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+#define RTC1_CONFIG_RELIABLE     false
+
+#define RTC1_INSTANCE_INDEX      (RTC0_ENABLED)
+#endif
+
+#define RTC2_ENABLED 0
+
+#if (RTC2_ENABLED == 1)
+#define RTC2_CONFIG_FREQUENCY    32768
+#define RTC2_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+#define RTC2_CONFIG_RELIABLE     false
+
+#define RTC2_INSTANCE_INDEX      (RTC0_ENABLED+RTC1_ENABLED)
+#endif
+
+
+#define RTC_COUNT                (RTC0_ENABLED+RTC1_ENABLED+RTC2_ENABLED)
+
+#define NRF_MAXIMUM_LATENCY_US 2000
+
+/* RNG */
+#define RNG_ENABLED 0
+
+#if (RNG_ENABLED == 1)
+#define RNG_CONFIG_ERROR_CORRECTION true
+#define RNG_CONFIG_POOL_SIZE        8
+#define RNG_CONFIG_IRQ_PRIORITY     APP_IRQ_PRIORITY_LOW
+#endif
+
+/* PWM */
+
+#define PWM0_ENABLED 0
+
+#if (PWM0_ENABLED == 1)
+#define PWM0_CONFIG_OUT0_PIN        2
+#define PWM0_CONFIG_OUT1_PIN        3
+#define PWM0_CONFIG_OUT2_PIN        4
+#define PWM0_CONFIG_OUT3_PIN        5
+#define PWM0_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+#define PWM0_CONFIG_BASE_CLOCK      NRF_PWM_CLK_1MHz
+#define PWM0_CONFIG_COUNT_MODE      NRF_PWM_MODE_UP
+#define PWM0_CONFIG_TOP_VALUE       1000
+#define PWM0_CONFIG_LOAD_MODE       NRF_PWM_LOAD_COMMON
+#define PWM0_CONFIG_STEP_MODE       NRF_PWM_STEP_AUTO
+
+#define PWM0_INSTANCE_INDEX 0
+#endif
+
+#define PWM1_ENABLED 0
+
+#if (PWM1_ENABLED == 1)
+#define PWM1_CONFIG_OUT0_PIN        2
+#define PWM1_CONFIG_OUT1_PIN        3
+#define PWM1_CONFIG_OUT2_PIN        4
+#define PWM1_CONFIG_OUT3_PIN        5
+#define PWM1_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+#define PWM1_CONFIG_BASE_CLOCK      NRF_PWM_CLK_1MHz
+#define PWM1_CONFIG_COUNT_MODE      NRF_PWM_MODE_UP
+#define PWM1_CONFIG_TOP_VALUE       1000
+#define PWM1_CONFIG_LOAD_MODE       NRF_PWM_LOAD_COMMON
+#define PWM1_CONFIG_STEP_MODE       NRF_PWM_STEP_AUTO
+
+#define PWM1_INSTANCE_INDEX (PWM0_ENABLED)
+#endif
+
+#define PWM2_ENABLED 0
+
+#if (PWM2_ENABLED == 1)
+#define PWM2_CONFIG_OUT0_PIN        2
+#define PWM2_CONFIG_OUT1_PIN        3
+#define PWM2_CONFIG_OUT2_PIN        4
+#define PWM2_CONFIG_OUT3_PIN        5
+#define PWM2_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+#define PWM2_CONFIG_BASE_CLOCK      NRF_PWM_CLK_1MHz
+#define PWM2_CONFIG_COUNT_MODE      NRF_PWM_MODE_UP
+#define PWM2_CONFIG_TOP_VALUE       1000
+#define PWM2_CONFIG_LOAD_MODE       NRF_PWM_LOAD_COMMON
+#define PWM2_CONFIG_STEP_MODE       NRF_PWM_STEP_AUTO
+
+#define PWM2_INSTANCE_INDEX (PWM0_ENABLED + PWM1_ENABLED)
+#endif
+
+#define PWM_COUNT   (PWM0_ENABLED + PWM1_ENABLED + PWM2_ENABLED)
+
+/* SPI */
+#define SPI0_ENABLED 0
+
+#if (SPI0_ENABLED == 1)
+#define SPI0_USE_EASY_DMA 0
+
+#define SPI0_CONFIG_SCK_PIN         2
+#define SPI0_CONFIG_MOSI_PIN        3
+#define SPI0_CONFIG_MISO_PIN        4
+#define SPI0_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+
+#define SPI0_INSTANCE_INDEX 0
+#endif
+
+#define SPI1_ENABLED 0
+
+#if (SPI1_ENABLED == 1)
+#define SPI1_USE_EASY_DMA 0
+
+#define SPI1_CONFIG_SCK_PIN         2
+#define SPI1_CONFIG_MOSI_PIN        3
+#define SPI1_CONFIG_MISO_PIN        4
+#define SPI1_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+
+#define SPI1_INSTANCE_INDEX (SPI0_ENABLED)
+#endif
+
+#define SPI2_ENABLED 0
+
+#if (SPI2_ENABLED == 1)
+#define SPI2_USE_EASY_DMA 0
+
+#define SPI2_CONFIG_SCK_PIN         2
+#define SPI2_CONFIG_MOSI_PIN        3
+#define SPI2_CONFIG_MISO_PIN        4
+#define SPI2_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+
+#define SPI2_INSTANCE_INDEX (SPI0_ENABLED + SPI1_ENABLED)
+#endif
+
+#define SPI_COUNT   (SPI0_ENABLED + SPI1_ENABLED + SPI2_ENABLED)
+
+/* SPIS */
+#define SPIS0_ENABLED 0
+
+#if (SPIS0_ENABLED == 1)
+#define SPIS0_CONFIG_SCK_PIN         2
+#define SPIS0_CONFIG_MOSI_PIN        3
+#define SPIS0_CONFIG_MISO_PIN        4
+#define SPIS0_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+
+#define SPIS0_INSTANCE_INDEX 0
+#endif
+
+#define SPIS1_ENABLED 0
+
+#if (SPIS1_ENABLED == 1)
+#define SPIS1_CONFIG_SCK_PIN         2
+#define SPIS1_CONFIG_MOSI_PIN        3
+#define SPIS1_CONFIG_MISO_PIN        4
+#define SPIS1_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+
+#define SPIS1_INSTANCE_INDEX SPIS0_ENABLED
+#endif
+
+#define SPIS2_ENABLED 0
+
+#if (SPIS2_ENABLED == 1)
+#define SPIS2_CONFIG_SCK_PIN         2
+#define SPIS2_CONFIG_MOSI_PIN        3
+#define SPIS2_CONFIG_MISO_PIN        4
+#define SPIS2_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+
+#define SPIS2_INSTANCE_INDEX (SPIS0_ENABLED + SPIS1_ENABLED)
+#endif
+
+#define SPIS_COUNT   (SPIS0_ENABLED + SPIS1_ENABLED + SPIS2_ENABLED)
+
+/* UART */
+#define UART0_ENABLED 0
+
+#if (UART0_ENABLED == 1)
+#define UART0_CONFIG_HWFC         NRF_UART_HWFC_DISABLED
+#define UART0_CONFIG_PARITY       NRF_UART_PARITY_EXCLUDED
+#define UART0_CONFIG_BAUDRATE     NRF_UART_BAUDRATE_115200
+#define UART0_CONFIG_PSEL_TXD     0
+#define UART0_CONFIG_PSEL_RXD     0
+#define UART0_CONFIG_PSEL_CTS     0
+#define UART0_CONFIG_PSEL_RTS     0
+#define UART0_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+#ifdef NRF52
+#define UART0_CONFIG_USE_EASY_DMA false
+//Compile time flag
+#define UART_EASY_DMA_SUPPORT     1
+#define UART_LEGACY_SUPPORT       1
+#endif //NRF52
+#endif
+
+#define TWI0_ENABLED 0
+
+#if (TWI0_ENABLED == 1)
+#define TWI0_USE_EASY_DMA 0
+
+#define TWI0_CONFIG_FREQUENCY    NRF_TWI_FREQ_100K
+#define TWI0_CONFIG_SCL          0
+#define TWI0_CONFIG_SDA          1
+#define TWI0_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+#define TWI0_INSTANCE_INDEX      0
+#endif
+
+#define TWI1_ENABLED 0
+
+#if (TWI1_ENABLED == 1)
+#define TWI1_USE_EASY_DMA 0
+
+#define TWI1_CONFIG_FREQUENCY    NRF_TWI_FREQ_100K
+#define TWI1_CONFIG_SCL          0
+#define TWI1_CONFIG_SDA          1
+#define TWI1_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+#define TWI1_INSTANCE_INDEX      (TWI0_ENABLED)
+#endif
+
+#define TWI_COUNT                (TWI0_ENABLED + TWI1_ENABLED)
+
+/* TWIS */
+#define TWIS0_ENABLED 0
+
+#if (TWIS0_ENABLED == 1)
+    #define TWIS0_CONFIG_ADDR0        0
+    #define TWIS0_CONFIG_ADDR1        0 /* 0: Disabled */
+    #define TWIS0_CONFIG_SCL          0
+    #define TWIS0_CONFIG_SDA          1
+    #define TWIS0_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+    #define TWIS0_INSTANCE_INDEX      0
+#endif
+
+#define TWIS1_ENABLED 0
+
+#if (TWIS1_ENABLED ==  1)
+    #define TWIS1_CONFIG_ADDR0        0
+    #define TWIS1_CONFIG_ADDR1        0 /* 0: Disabled */
+    #define TWIS1_CONFIG_SCL          0
+    #define TWIS1_CONFIG_SDA          1
+    #define TWIS1_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+
+    #define TWIS1_INSTANCE_INDEX      (TWIS0_ENABLED)
+#endif
+
+#define TWIS_COUNT (TWIS0_ENABLED + TWIS1_ENABLED)
+/* For more documentation see nrf_drv_twis.h file */
+#define TWIS_ASSUME_INIT_AFTER_RESET_ONLY 0
+/* For more documentation see nrf_drv_twis.h file */
+#define TWIS_NO_SYNC_MODE 0
+
+/* QDEC */
+#define QDEC_ENABLED 0
+
+#if (QDEC_ENABLED == 1)
+#define QDEC_CONFIG_REPORTPER    NRF_QDEC_REPORTPER_10
+#define QDEC_CONFIG_SAMPLEPER    NRF_QDEC_SAMPLEPER_16384us
+#define QDEC_CONFIG_PIO_A        1
+#define QDEC_CONFIG_PIO_B        2
+#define QDEC_CONFIG_PIO_LED      3
+#define QDEC_CONFIG_LEDPRE       511
+#define QDEC_CONFIG_LEDPOL       NRF_QDEC_LEPOL_ACTIVE_HIGH
+#define QDEC_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+#define QDEC_CONFIG_DBFEN        false
+#define QDEC_CONFIG_SAMPLE_INTEN false
+#endif
+
+/* ADC */
+#define ADC_ENABLED 0
+
+#if (ADC_ENABLED == 1)
+#define ADC_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+#endif
+
+
+/* SAADC */
+#define SAADC_ENABLED 0
+
+#if (SAADC_ENABLED == 1)
+#define SAADC_CONFIG_RESOLUTION      NRF_SAADC_RESOLUTION_10BIT
+#define SAADC_CONFIG_OVERSAMPLE      NRF_SAADC_OVERSAMPLE_DISABLED
+#define SAADC_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+#endif
+
+/* PDM */
+#define PDM_ENABLED 0
+
+#if (PDM_ENABLED == 1)
+#define PDM_CONFIG_MODE            NRF_PDM_MODE_MONO
+#define PDM_CONFIG_EDGE            NRF_PDM_EDGE_LEFTFALLING
+#define PDM_CONFIG_CLOCK_FREQ      NRF_PDM_FREQ_1032K
+#define PDM_CONFIG_IRQ_PRIORITY    APP_IRQ_PRIORITY_LOW
+#endif
+
+/* COMP */
+#define COMP_ENABLED 0
+
+#if (COMP_ENABLED == 1)
+#define COMP_CONFIG_REF     		NRF_COMP_REF_Int1V8
+#define COMP_CONFIG_MAIN_MODE		NRF_COMP_MAIN_MODE_SE
+#define COMP_CONFIG_SPEED_MODE		NRF_COMP_SP_MODE_High
+#define COMP_CONFIG_HYST			NRF_COMP_HYST_NoHyst
+#define COMP_CONFIG_ISOURCE			NRF_COMP_ISOURCE_Off
+#define COMP_CONFIG_IRQ_PRIORITY 	APP_IRQ_PRIORITY_LOW
+#define COMP_CONFIG_INPUT        	NRF_COMP_INPUT_0
+#endif
+
+/* LPCOMP */
+#define LPCOMP_ENABLED 0
+
+#if (LPCOMP_ENABLED == 1)
+#define LPCOMP_CONFIG_REFERENCE    NRF_LPCOMP_REF_SUPPLY_4_8
+#define LPCOMP_CONFIG_DETECTION    NRF_LPCOMP_DETECT_DOWN
+#define LPCOMP_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_LOW
+#define LPCOMP_CONFIG_INPUT        NRF_LPCOMP_INPUT_0
+#endif
+
+/* WDT */
+#define WDT_ENABLED 0
+
+#if (WDT_ENABLED == 1)
+#define WDT_CONFIG_BEHAVIOUR     NRF_WDT_BEHAVIOUR_RUN_SLEEP
+#define WDT_CONFIG_RELOAD_VALUE  2000
+#define WDT_CONFIG_IRQ_PRIORITY  APP_IRQ_PRIORITY_HIGH
+#endif
+
+/* SWI EGU */
+#ifdef NRF52
+    #define EGU_ENABLED 0
+#endif
+
+/* I2S */
+#define I2S_ENABLED 0
+
+#if (I2S_ENABLED == 1)
+#define I2S_CONFIG_SCK_PIN      22
+#define I2S_CONFIG_LRCK_PIN     23
+#define I2S_CONFIG_MCK_PIN      NRF_DRV_I2S_PIN_NOT_USED
+#define I2S_CONFIG_SDOUT_PIN    24
+#define I2S_CONFIG_SDIN_PIN     25
+#define I2S_CONFIG_IRQ_PRIORITY APP_IRQ_PRIORITY_HIGH
+#define I2S_CONFIG_MASTER       NRF_I2S_MODE_MASTER
+#define I2S_CONFIG_FORMAT       NRF_I2S_FORMAT_I2S
+#define I2S_CONFIG_ALIGN        NRF_I2S_ALIGN_LEFT
+#define I2S_CONFIG_SWIDTH       NRF_I2S_SWIDTH_16BIT
+#define I2S_CONFIG_CHANNELS     NRF_I2S_CHANNELS_STEREO
+#define I2S_CONFIG_MCK_SETUP    NRF_I2S_MCK_32MDIV8
+#define I2S_CONFIG_RATIO        NRF_I2S_RATIO_256X
+#endif
+
+#include "nrf_drv_config_validation.h"
+
+#endif // NRF_DRV_CONFIG_H

--- a/lib/simple_ble.c
+++ b/lib/simple_ble.c
@@ -54,7 +54,7 @@ ble_gap_adv_params_t m_adv_params;
 ble_gap_sec_params_t m_sec_params = {
     SEC_PARAM_BOND,
     SEC_PARAM_MITM,
-#ifdef SOFTDEVICE_s130
+#if defined(SOFTDEVICE_s130) || defined(SOFTDEVICE_s132)
     SEC_PARAM_LESC,
     SEC_PARAM_KEYPRESS,
 #endif
@@ -62,7 +62,7 @@ ble_gap_sec_params_t m_sec_params = {
     SEC_PARAM_OOB,
     SEC_PARAM_MIN_KEY_SIZE,
     SEC_PARAM_MAX_KEY_SIZE,
-#ifdef SOFTDEVICE_s130
+#if defined(SOFTDEVICE_s130) || defined(SOFTDEVICE_s132)
     {0, 0, 0, 0},
     {0, 0, 0, 0}
 #endif
@@ -121,7 +121,7 @@ void __attribute__((weak)) ble_evt_adv_report(ble_evt_t* p_ble_evt);
 void __attribute__((weak)) ble_error(uint32_t error_code);
 
 
-#ifndef SOFTDEVICE_s130 // This function is called app_error_fault_handler in the SDK 11
+#if !defined(SOFTDEVICE_s130) && !defined(SOFTDEVICE_s132) // This function is called app_error_fault_handler in the SDK 11
 void app_error_handler(uint32_t error_code, uint32_t line_num, const uint8_t * p_file_name) {
 #else
 void __attribute__((weak)) app_error_fault_handler(uint32_t error_code, __attribute__ ((unused)) uint32_t line_num, __attribute__ ((unused)) uint32_t info) {
@@ -293,7 +293,7 @@ static void on_ble_evt(ble_evt_t * p_ble_evt) {
         case BLE_GAP_EVT_ADV_REPORT:
             {
 #ifdef ENABLE_DFU
-#ifdef SOFTDEVICE_s130
+#if defined(SOFTDEVICE_s130) || defined(SOFTDEVICE_s132)
               // check if DFU advertisement
               uint8_t data[31];
               int len = parse_adata(p_ble_evt, 0xFF, data);
@@ -389,7 +389,7 @@ void __attribute__((weak)) ble_address_set (void) {
 void __attribute__((weak)) ble_stack_init (void) {
     uint32_t err_code;
 
-#ifdef SOFTDEVICE_s130
+#if defined(SOFTDEVICE_s130) || defined(SOFTDEVICE_s132)
     // Softdevice 130 2.0.0 changes how the softdevice init procedure works.
     nrf_clock_lf_cfg_t clock_lf_cfg = {
         .source        = NRF_CLOCK_LF_SRC_RC,
@@ -554,7 +554,7 @@ void __attribute__((weak)) initialize_app_timer (void) {
  ******************************************************************************/
 void __attribute__((weak)) advertising_start(void) {
     uint32_t err_code = sd_ble_gap_adv_start(&m_adv_params);
-#ifdef SOFTDEVICE_s130
+#if defined(SOFTDEVICE_s130) || defined(SOFTDEVICE_s132)
     if (err_code == NRF_ERROR_CONN_COUNT) {
         // ignore Connection Count problems. Connectable advertising seems to work just fine
         return;
@@ -918,7 +918,7 @@ uint32_t simple_ble_stack_char_set (simple_ble_char_t* char_handle, uint16_t len
     return sd_ble_gatts_value_set(app.conn_handle, char_handle->char_handle.value_handle, &value);
 }
 
-#ifdef SOFTDEVICE_s130
+#if defined(SOFTDEVICE_s130) || defined(SOFTDEVICE_s132)
 static const ble_gap_scan_params_t m_scan_param = {
     .active = 0,                   // Active scanning not set.
     .selective = 0,                // Selective scanning not set.

--- a/make/Makefile
+++ b/make/Makefile
@@ -231,7 +231,11 @@ BOOTLOADER_REGION_START = $(addprefix 0x, $(shell echo "obase=16; (${FLASH_KB}-1
 BOOTLOADER_SETTINGS_ADDRESS = $(addprefix 0x, $(shell echo "obase=16; (${FLASH_KB}-2)*1024" | bc))
 
 # Need some common options for interacting with the chip over JTAG
+ifeq ($(NRF_IC), nrf52832)
+JLINK_OPTIONS = -device nrf52 -if swd -speed 1000
+else
 JLINK_OPTIONS = -device $(NRF_IC) -if swd -speed 1000
+endif
 
 # If not set in app makefile, lets optimize for size
 CFLAGS += -Os
@@ -262,7 +266,7 @@ SOURCE_PATHS += $(BASE_DIR)/services/
 SOURCE_PATHS += $(BASE_DIR)/startup/
 
 # Add paths for each SDK version
-ifeq ($(NRF_MODEL), nrf51)
+ifeq ($(NRF_MODEL), $(filter $(NRF_MODEL),nrf51 nrf52))
 ifeq ($(SDK_VERSION), 12)
 
 	# Set the path
@@ -801,7 +805,13 @@ VPATH = $(SOURCE_PATHS)
 
 OUTPUT_PATH ?= _build/
 
-CPUFLAGS = -mthumb -mcpu=cortex-m0 -march=armv6-m
+ifneq (,$(filter $(NRF_IC),nrf52832 nrf52833 nrf52840))
+	#CPUFLAGS = -mthumb -mabi=aapcs -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=soft -mfpu=fpv4-sp-d16
+	CPUFLAGS = -mthumb -mcpu=cortex-m4 -march=armv7e-m 
+else
+	CPUFLAGS = -mthumb -mcpu=cortex-m0 -march=armv6-m
+endif
+
 CFLAGS += -std=gnu99 -c $(CPUFLAGS) -Wall -Wextra -Wno-unused-parameter -Werror=return-type -D$(DEVICE) -D$(BOARD) -D$(NRF_IC_UPPER) -DSDK_VERSION_$(SDK_VERSION) -DSOFTDEVICE_$(SOFTDEVICE_MODEL)
 CFLAGS += -s -ffunction-sections -fdata-sections
 CFLAGS += -D$(shell echo $(SOFTDEVICE_MODEL) | tr a-z A-Z)

--- a/make/Makefile.posix
+++ b/make/Makefile.posix
@@ -75,7 +75,7 @@ ifneq ($(SOFTDEVICE_MODEL),blank)
 	@$(OBJCOPY) -Iihex -Obinary $(SOFTDEVICE) $(SOFTDEVICE_OUTPUT:.hex=.bin)
 	@$(JLINK) $(OUTPUT_PATH)test-softdevice.jlink
 	@dd skip=$(shell printf "%d" $(SOFTDEVICE_TEST_ADDR)) count=$(shell printf "%d" $(SOFTDEVICE_TEST_LEN)) if=$(SOFTDEVICE_OUTPUT:.hex=.bin) of=$(SOFTDEVICE_TEST_BIN) bs=1
-	@diff -q $(SOFTDEVICE_TEST_FLASH) $(SOFTDEVICE_TEST_BIN) || $(MAKE) flash-softdevice
+	@diff -q $(SOFTDEVICE_TEST_FLASH) $(SOFTDEVICE_TEST_BIN) || $(MAKE) $(subst flash,,$(MAKECMDGOALS)) flash-softdevice
 endif
 
 # address and length determined experimentally. Works for s110_7, s110_8, s120_2, and s130_1

--- a/make/ld/gcc_nrf52832_s132_6.0.0_64_512.ld
+++ b/make/ld/gcc_nrf52832_s132_6.0.0_64_512.ld
@@ -1,0 +1,137 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x0 + 152K, LENGTH = 512K - 152K - 4K /* 152 kB is taken by s132, 4 kB is taken by bootloader settings */
+  RAM (rwx) :  ORIGIN = 0x200098a8, LENGTH = 0x6758 /* worst case taken from example apps. this can be significantly reduced if needed */
+  bootloader_settings_page (r) : ORIGIN = 0x0 + 512K - 4K LENGTH = 4K
+  uicr_bootloader_start_address (r) : ORIGIN = 0x10001014, LENGTH = 0x4
+}
+
+SECTIONS
+{
+  .bootloader_settings_page(NOLOAD) :
+  {
+    PROVIDE(__start_bootloader_settings_page = .);
+    KEEP(*(SORT(.bootloader_settings_page*)))
+    PROVIDE(__stop_bootloader_settings_page = .);
+  } > bootloader_settings_page
+  .uicr_bootloader_start_address :
+  {
+    PROVIDE(__start_uicr_bootloader_start_address = .);
+    KEEP(*(SORT(.uicr_bootloader_start_address*)))
+    PROVIDE(__stop_uicr_bootloader_start_address = .);
+  } > uicr_bootloader_start_address
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .mem_section_dummy_ram :
+  {
+  }
+  .log_dynamic_data :
+  {
+    PROVIDE(__start_log_dynamic_data = .);
+    KEEP(*(SORT(.log_dynamic_data*)))
+    PROVIDE(__stop_log_dynamic_data = .);
+  } > RAM
+  .cli_sorted_cmd_ptrs :
+  {
+    PROVIDE(__start_cli_sorted_cmd_ptrs = .);
+    KEEP(*(.cli_sorted_cmd_ptrs))
+    PROVIDE(__stop_cli_sorted_cmd_ptrs = .);
+  } > RAM
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+
+} INSERT AFTER .data;
+
+SECTIONS
+{
+  .mem_section_dummy_rom :
+  {
+  }
+  .sdh_soc_observers :
+  {
+    PROVIDE(__start_sdh_soc_observers = .);
+    KEEP(*(SORT(.sdh_soc_observers*)))
+    PROVIDE(__stop_sdh_soc_observers = .);
+  } > FLASH
+  .crypto_data :
+  {
+    PROVIDE(__start_crypto_data = .);
+    KEEP(*(SORT(.crypto_data*)))
+    PROVIDE(__stop_crypto_data = .);
+  } > FLASH
+  .log_const_data :
+  {
+    PROVIDE(__start_log_const_data = .);
+    KEEP(*(SORT(.log_const_data*)))
+    PROVIDE(__stop_log_const_data = .);
+  } > FLASH
+    .nrf_balloc :
+  {
+    PROVIDE(__start_nrf_balloc = .);
+    KEEP(*(.nrf_balloc))
+    PROVIDE(__stop_nrf_balloc = .);
+  } > FLASH
+    .nrf_queue :
+  {
+    PROVIDE(__start_nrf_queue = .);
+    KEEP(*(.nrf_queue))
+    PROVIDE(__stop_nrf_queue = .);
+  } > FLASH
+  .sdh_state_observers :
+  {
+    PROVIDE(__start_sdh_state_observers = .);
+    KEEP(*(SORT(.sdh_state_observers*)))
+    PROVIDE(__stop_sdh_state_observers = .);
+  } > FLASH
+  .sdh_stack_observers :
+  {
+    PROVIDE(__start_sdh_stack_observers = .);
+    KEEP(*(SORT(.sdh_stack_observers*)))
+    PROVIDE(__stop_sdh_stack_observers = .);
+  } > FLASH
+  .sdh_req_observers :
+  {
+    PROVIDE(__start_sdh_req_observers = .);
+    KEEP(*(SORT(.sdh_req_observers*)))
+    PROVIDE(__stop_sdh_req_observers = .);
+  } > FLASH
+    .cli_command :
+  {
+    PROVIDE(__start_cli_command = .);
+    KEEP(*(.cli_command))
+    PROVIDE(__stop_cli_command = .);
+  } > FLASH
+  .pwr_mgmt_data :
+  {
+    PROVIDE(__start_pwr_mgmt_data = .);
+    KEEP(*(SORT(.pwr_mgmt_data*)))
+    PROVIDE(__stop_pwr_mgmt_data = .);
+  } > FLASH
+  .sdh_ble_observers :
+  {
+    PROVIDE(__start_sdh_ble_observers = .);
+    KEEP(*(SORT(.sdh_ble_observers*)))
+    PROVIDE(__stop_sdh_ble_observers = .);
+  } > FLASH
+  .dfu_trans :
+  {
+    PROVIDE(__start_dfu_trans = .);
+    KEEP(*(SORT(.dfu_trans*)))
+    PROVIDE(__stop_dfu_trans = .);
+  } > FLASH
+
+} INSERT AFTER .text
+
+INCLUDE "nrf_common.ld"

--- a/make/ld/gcc_nrf52_s132_2.0.0_64_512.ld
+++ b/make/ld/gcc_nrf52_s132_2.0.0_64_512.ld
@@ -1,0 +1,137 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x0 + 112K, LENGTH = 512K - 112K - 4K /* 112K kB is taken by s132, 4 kB is taken by bootloader settings */
+  RAM (rwx) :  ORIGIN = 0x200098a8, LENGTH = 0x6758 /* worst case taken from example apps. this can be significantly reduced if needed */
+  bootloader_settings_page (r) : ORIGIN = 0x0 + 512K - 4K LENGTH = 4K
+  uicr_bootloader_start_address (r) : ORIGIN = 0x10001014, LENGTH = 0x4
+}
+
+SECTIONS
+{
+  .bootloader_settings_page(NOLOAD) :
+  {
+    PROVIDE(__start_bootloader_settings_page = .);
+    KEEP(*(SORT(.bootloader_settings_page*)))
+    PROVIDE(__stop_bootloader_settings_page = .);
+  } > bootloader_settings_page
+  .uicr_bootloader_start_address :
+  {
+    PROVIDE(__start_uicr_bootloader_start_address = .);
+    KEEP(*(SORT(.uicr_bootloader_start_address*)))
+    PROVIDE(__stop_uicr_bootloader_start_address = .);
+  } > uicr_bootloader_start_address
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .mem_section_dummy_ram :
+  {
+  }
+  .log_dynamic_data :
+  {
+    PROVIDE(__start_log_dynamic_data = .);
+    KEEP(*(SORT(.log_dynamic_data*)))
+    PROVIDE(__stop_log_dynamic_data = .);
+  } > RAM
+  .cli_sorted_cmd_ptrs :
+  {
+    PROVIDE(__start_cli_sorted_cmd_ptrs = .);
+    KEEP(*(.cli_sorted_cmd_ptrs))
+    PROVIDE(__stop_cli_sorted_cmd_ptrs = .);
+  } > RAM
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+
+} INSERT AFTER .data;
+
+SECTIONS
+{
+  .mem_section_dummy_rom :
+  {
+  }
+  .sdh_soc_observers :
+  {
+    PROVIDE(__start_sdh_soc_observers = .);
+    KEEP(*(SORT(.sdh_soc_observers*)))
+    PROVIDE(__stop_sdh_soc_observers = .);
+  } > FLASH
+  .crypto_data :
+  {
+    PROVIDE(__start_crypto_data = .);
+    KEEP(*(SORT(.crypto_data*)))
+    PROVIDE(__stop_crypto_data = .);
+  } > FLASH
+  .log_const_data :
+  {
+    PROVIDE(__start_log_const_data = .);
+    KEEP(*(SORT(.log_const_data*)))
+    PROVIDE(__stop_log_const_data = .);
+  } > FLASH
+    .nrf_balloc :
+  {
+    PROVIDE(__start_nrf_balloc = .);
+    KEEP(*(.nrf_balloc))
+    PROVIDE(__stop_nrf_balloc = .);
+  } > FLASH
+    .nrf_queue :
+  {
+    PROVIDE(__start_nrf_queue = .);
+    KEEP(*(.nrf_queue))
+    PROVIDE(__stop_nrf_queue = .);
+  } > FLASH
+  .sdh_state_observers :
+  {
+    PROVIDE(__start_sdh_state_observers = .);
+    KEEP(*(SORT(.sdh_state_observers*)))
+    PROVIDE(__stop_sdh_state_observers = .);
+  } > FLASH
+  .sdh_stack_observers :
+  {
+    PROVIDE(__start_sdh_stack_observers = .);
+    KEEP(*(SORT(.sdh_stack_observers*)))
+    PROVIDE(__stop_sdh_stack_observers = .);
+  } > FLASH
+  .sdh_req_observers :
+  {
+    PROVIDE(__start_sdh_req_observers = .);
+    KEEP(*(SORT(.sdh_req_observers*)))
+    PROVIDE(__stop_sdh_req_observers = .);
+  } > FLASH
+    .cli_command :
+  {
+    PROVIDE(__start_cli_command = .);
+    KEEP(*(.cli_command))
+    PROVIDE(__stop_cli_command = .);
+  } > FLASH
+  .pwr_mgmt_data :
+  {
+    PROVIDE(__start_pwr_mgmt_data = .);
+    KEEP(*(SORT(.pwr_mgmt_data*)))
+    PROVIDE(__stop_pwr_mgmt_data = .);
+  } > FLASH
+  .sdh_ble_observers :
+  {
+    PROVIDE(__start_sdh_ble_observers = .);
+    KEEP(*(SORT(.sdh_ble_observers*)))
+    PROVIDE(__stop_sdh_ble_observers = .);
+  } > FLASH
+  .dfu_trans :
+  {
+    PROVIDE(__start_dfu_trans = .);
+    KEEP(*(SORT(.dfu_trans*)))
+    PROVIDE(__stop_dfu_trans = .);
+  } > FLASH
+
+} INSERT AFTER .text
+
+INCLUDE "nrf_common.ld"

--- a/make/ld/gcc_nrf52_s132_3.0.0_64_512.ld
+++ b/make/ld/gcc_nrf52_s132_3.0.0_64_512.ld
@@ -1,0 +1,137 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x0 + 124K, LENGTH = 512K - 124K - 4K /* 124K kB is taken by s132, 4 kB is taken by bootloader settings */
+  RAM (rwx) :  ORIGIN = 0x200098a8, LENGTH = 0x6758 /* worst case taken from example apps. this can be significantly reduced if needed */
+  bootloader_settings_page (r) : ORIGIN = 0x0 + 512K - 4K LENGTH = 4K
+  uicr_bootloader_start_address (r) : ORIGIN = 0x10001014, LENGTH = 0x4
+}
+
+SECTIONS
+{
+  .bootloader_settings_page(NOLOAD) :
+  {
+    PROVIDE(__start_bootloader_settings_page = .);
+    KEEP(*(SORT(.bootloader_settings_page*)))
+    PROVIDE(__stop_bootloader_settings_page = .);
+  } > bootloader_settings_page
+  .uicr_bootloader_start_address :
+  {
+    PROVIDE(__start_uicr_bootloader_start_address = .);
+    KEEP(*(SORT(.uicr_bootloader_start_address*)))
+    PROVIDE(__stop_uicr_bootloader_start_address = .);
+  } > uicr_bootloader_start_address
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .mem_section_dummy_ram :
+  {
+  }
+  .log_dynamic_data :
+  {
+    PROVIDE(__start_log_dynamic_data = .);
+    KEEP(*(SORT(.log_dynamic_data*)))
+    PROVIDE(__stop_log_dynamic_data = .);
+  } > RAM
+  .cli_sorted_cmd_ptrs :
+  {
+    PROVIDE(__start_cli_sorted_cmd_ptrs = .);
+    KEEP(*(.cli_sorted_cmd_ptrs))
+    PROVIDE(__stop_cli_sorted_cmd_ptrs = .);
+  } > RAM
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+
+} INSERT AFTER .data;
+
+SECTIONS
+{
+  .mem_section_dummy_rom :
+  {
+  }
+  .sdh_soc_observers :
+  {
+    PROVIDE(__start_sdh_soc_observers = .);
+    KEEP(*(SORT(.sdh_soc_observers*)))
+    PROVIDE(__stop_sdh_soc_observers = .);
+  } > FLASH
+  .crypto_data :
+  {
+    PROVIDE(__start_crypto_data = .);
+    KEEP(*(SORT(.crypto_data*)))
+    PROVIDE(__stop_crypto_data = .);
+  } > FLASH
+  .log_const_data :
+  {
+    PROVIDE(__start_log_const_data = .);
+    KEEP(*(SORT(.log_const_data*)))
+    PROVIDE(__stop_log_const_data = .);
+  } > FLASH
+    .nrf_balloc :
+  {
+    PROVIDE(__start_nrf_balloc = .);
+    KEEP(*(.nrf_balloc))
+    PROVIDE(__stop_nrf_balloc = .);
+  } > FLASH
+    .nrf_queue :
+  {
+    PROVIDE(__start_nrf_queue = .);
+    KEEP(*(.nrf_queue))
+    PROVIDE(__stop_nrf_queue = .);
+  } > FLASH
+  .sdh_state_observers :
+  {
+    PROVIDE(__start_sdh_state_observers = .);
+    KEEP(*(SORT(.sdh_state_observers*)))
+    PROVIDE(__stop_sdh_state_observers = .);
+  } > FLASH
+  .sdh_stack_observers :
+  {
+    PROVIDE(__start_sdh_stack_observers = .);
+    KEEP(*(SORT(.sdh_stack_observers*)))
+    PROVIDE(__stop_sdh_stack_observers = .);
+  } > FLASH
+  .sdh_req_observers :
+  {
+    PROVIDE(__start_sdh_req_observers = .);
+    KEEP(*(SORT(.sdh_req_observers*)))
+    PROVIDE(__stop_sdh_req_observers = .);
+  } > FLASH
+    .cli_command :
+  {
+    PROVIDE(__start_cli_command = .);
+    KEEP(*(.cli_command))
+    PROVIDE(__stop_cli_command = .);
+  } > FLASH
+  .pwr_mgmt_data :
+  {
+    PROVIDE(__start_pwr_mgmt_data = .);
+    KEEP(*(SORT(.pwr_mgmt_data*)))
+    PROVIDE(__stop_pwr_mgmt_data = .);
+  } > FLASH
+  .sdh_ble_observers :
+  {
+    PROVIDE(__start_sdh_ble_observers = .);
+    KEEP(*(SORT(.sdh_ble_observers*)))
+    PROVIDE(__stop_sdh_ble_observers = .);
+  } > FLASH
+  .dfu_trans :
+  {
+    PROVIDE(__start_dfu_trans = .);
+    KEEP(*(SORT(.dfu_trans*)))
+    PROVIDE(__stop_dfu_trans = .);
+  } > FLASH
+
+} INSERT AFTER .text
+
+INCLUDE "nrf_common.ld"

--- a/make/ld/nrf_common.ld
+++ b/make/ld/nrf_common.ld
@@ -1,0 +1,169 @@
+/* Linker script for Nordic Semiconductor nRF devices
+ *
+ * Version: Sourcery G++ 4.5-1
+ * Support: https://support.codesourcery.com/GNUToolchain/
+ *
+ * Copyright (c) 2007, 2008, 2009, 2010 CodeSourcery, Inc.
+ *
+ * The authors hereby grant permission to use, copy, modify, distribute,
+ * and license this software and its documentation for any purpose, provided
+ * that existing copyright notices are retained in all copies and that this
+ * notice is included verbatim in any distributions.  No written agreement,
+ * license, or royalty fee is required for any of the authorized uses.
+ * Modifications to this software may be copyrighted by their authors
+ * and need not follow the licensing terms described here, provided that
+ * the new terms are clearly indicated on the first page of each file where
+ * they apply.
+ */
+OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapBase
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    . = ALIGN(4);
+    __etext = .;
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        KEEP(*(.jcr*))
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+    } > RAM
+    
+    .heap (COPY):
+    {
+        __HeapBase = .;
+        __end__ = .;
+        PROVIDE(end = .);
+        KEEP(*(.heap*))
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        KEEP(*(.stack*))
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+    
+    /* Check if text sections + data exceeds FLASH limit */
+    DataInitFlashUsed = __bss_start__ - __data_start__;
+    CodeFlashUsed = __etext - ORIGIN(FLASH);
+    TotalFlashUsed = CodeFlashUsed + DataInitFlashUsed;
+    ASSERT(TotalFlashUsed <= LENGTH(FLASH), "region FLASH overflowed with .data and user data")
+    
+}

--- a/startup/startup_nrf52.s
+++ b/startup/startup_nrf52.s
@@ -1,0 +1,522 @@
+/* Copyright (c) 2013 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+    .syntax unified
+    .arch armv7e-m
+
+
+    .section .stack
+    .align 3
+#ifdef __STACK_SIZE
+    .equ    Stack_Size, __STACK_SIZE
+#else
+    .equ    Stack_Size, 8192
+#endif
+    .globl __StackTop
+    .globl __StackLimit
+__StackLimit:
+    .space Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 8192
+#endif
+    .globl __HeapBase
+    .globl __HeapLimit
+__HeapBase:
+    .if Heap_Size
+    .space Heap_Size
+    .endif
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+    
+    .section .isr_vector
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long   __StackTop                  /* Top of Stack */
+    .long   Reset_Handler
+    .long   NMI_Handler
+    .long   HardFault_Handler
+    .long   MemoryManagement_Handler
+    .long   BusFault_Handler
+    .long   UsageFault_Handler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   SVC_Handler
+    .long   DebugMonitor_Handler
+    .long   0                           /*Reserved */
+    .long   PendSV_Handler
+    .long   SysTick_Handler
+
+  /* External Interrupts */
+    .long   POWER_CLOCK_IRQHandler
+    .long   RADIO_IRQHandler
+    .long   UARTE0_UART0_IRQHandler
+    .long   SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler
+    .long   SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler
+    .long   NFCT_IRQHandler
+    .long   GPIOTE_IRQHandler
+    .long   SAADC_IRQHandler
+    .long   TIMER0_IRQHandler
+    .long   TIMER1_IRQHandler
+    .long   TIMER2_IRQHandler
+    .long   RTC0_IRQHandler
+    .long   TEMP_IRQHandler
+    .long   RNG_IRQHandler
+    .long   ECB_IRQHandler
+    .long   CCM_AAR_IRQHandler
+    .long   WDT_IRQHandler
+    .long   RTC1_IRQHandler
+    .long   QDEC_IRQHandler
+    .long   COMP_LPCOMP_IRQHandler
+    .long   SWI0_EGU0_IRQHandler
+    .long   SWI1_EGU1_IRQHandler
+    .long   SWI2_EGU2_IRQHandler
+    .long   SWI3_EGU3_IRQHandler
+    .long   SWI4_EGU4_IRQHandler
+    .long   SWI5_EGU5_IRQHandler
+    .long   TIMER3_IRQHandler
+    .long   TIMER4_IRQHandler
+    .long   PWM0_IRQHandler
+    .long   PDM_IRQHandler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   MWU_IRQHandler
+    .long   PWM1_IRQHandler
+    .long   PWM2_IRQHandler
+    .long   SPIM2_SPIS2_SPI2_IRQHandler
+    .long   RTC2_IRQHandler
+    .long   I2S_IRQHandler
+    .long   FPU_IRQHandler
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+    .long   0                           /*Reserved */
+
+    .size __isr_vector, . - __isr_vector
+
+/* Reset Handler */
+
+
+    .text
+    .thumb
+    .thumb_func
+    .align 1
+    .globl Reset_Handler
+    .type Reset_Handler, %function
+Reset_Handler:
+				
+				
+/* Loop to copy data from read only memory to RAM. 
+ * The ranges of copy from/to are specified by following symbols:
+ *      __etext: LMA of start of the section to copy from. Usually end of text
+ *      __data_start__: VMA of start of the section to copy to.
+ *      __bss_start__: VMA of end of the section to copy to. Normally __data_end__ is used, but by using __bss_start__ 
+ *                    the user can add their own initialized data section before BSS section with the INTERT AFTER command. 
+ *
+ * All addresses must be aligned to 4 bytes boundary.
+ */
+    ldr r1, =__etext
+    ldr r2, =__data_start__
+    ldr r3, =__bss_start__
+
+    subs r3, r2
+    ble .L_loop1_done
+
+.L_loop1:
+    subs r3, #4
+    ldr r0, [r1,r3]
+    str r0, [r2,r3]
+    bgt .L_loop1
+
+.L_loop1_done:
+
+/* This part of work usually is done in C library startup code. Otherwise,
+ * define __STARTUP_CLEAR_BSS to enable it in this startup. This section 
+ * clears the RAM where BSS data is located.
+ *
+ * The BSS section is specified by following symbols
+ *    __bss_start__: start of the BSS section.
+ *    __bss_end__: end of the BSS section.
+ *
+ * All addresses must be aligned to 4 bytes boundary.
+ */
+    ldr r1, =__bss_start__
+    ldr r2, =__bss_end__
+
+    movs r0, 0
+
+    subs r2, r1
+    ble .L_loop3_done
+
+.L_loop3:
+    subs r2, #4
+    str r0, [r1, r2]
+    bgt .L_loop3
+    
+.L_loop3_done:
+
+ 
+/* Execute SystemInit function. */
+    bl SystemInit
+
+/* Inizialize C library */
+    bl __libc_init_array
+ 
+ /* Call main function */
+    bl main    
+    
+    .pool
+    .size   Reset_Handler,.-Reset_Handler
+
+    .section ".text"
+
+
+/* Dummy Exception Handlers (infinite loops which can be modified) */
+
+    .weak   NMI_Handler
+    .type   NMI_Handler, %function
+NMI_Handler:
+    b       .
+    .size   NMI_Handler, . - NMI_Handler
+
+
+    .weak   HardFault_Handler
+    .type   HardFault_Handler, %function
+HardFault_Handler:
+    b       .
+    .size   HardFault_Handler, . - HardFault_Handler
+
+
+    .weak   MemoryManagement_Handler
+    .type   MemoryManagement_Handler, %function
+MemoryManagement_Handler:
+    b       .
+    .size   MemoryManagement_Handler, . - MemoryManagement_Handler
+
+
+    .weak   BusFault_Handler
+    .type   BusFault_Handler, %function
+BusFault_Handler:
+    b       .
+    .size   BusFault_Handler, . - BusFault_Handler
+
+
+    .weak   UsageFault_Handler
+    .type   UsageFault_Handler, %function
+UsageFault_Handler:
+    b       .
+    .size   UsageFault_Handler, . - UsageFault_Handler
+
+
+    .weak   SVC_Handler
+    .type   SVC_Handler, %function
+SVC_Handler:
+    b       .
+    .size   SVC_Handler, . - SVC_Handler
+
+
+    .weak   DebugMonitor_Handler
+    .type   DebugMonitor_Handler, %function
+DebugMonitor_Handler:
+    b       .
+    .size   DebugMonitor_Handler, . - DebugMonitor_Handler
+
+
+    .weak   PendSV_Handler
+    .type   PendSV_Handler, %function
+PendSV_Handler:
+    b       .
+    .size   PendSV_Handler, . - PendSV_Handler
+
+
+    .weak   SysTick_Handler
+    .type   SysTick_Handler, %function
+SysTick_Handler:
+    b       .
+    .size   SysTick_Handler, . - SysTick_Handler
+
+
+/* IRQ Handlers */
+
+    .globl  Default_Handler
+    .type   Default_Handler, %function
+Default_Handler:
+    b       .
+    .size   Default_Handler, . - Default_Handler
+
+    .macro  IRQ handler
+    .weak   \handler
+    .set    \handler, Default_Handler
+    .endm
+
+    IRQ  POWER_CLOCK_IRQHandler
+    IRQ  RADIO_IRQHandler
+    IRQ  UARTE0_UART0_IRQHandler
+    IRQ  SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler
+    IRQ  SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler
+    IRQ  NFCT_IRQHandler
+    IRQ  GPIOTE_IRQHandler
+    IRQ  SAADC_IRQHandler
+    IRQ  TIMER0_IRQHandler
+    IRQ  TIMER1_IRQHandler
+    IRQ  TIMER2_IRQHandler
+    IRQ  RTC0_IRQHandler
+    IRQ  TEMP_IRQHandler
+    IRQ  RNG_IRQHandler
+    IRQ  ECB_IRQHandler
+    IRQ  CCM_AAR_IRQHandler
+    IRQ  WDT_IRQHandler
+    IRQ  RTC1_IRQHandler
+    IRQ  QDEC_IRQHandler
+    IRQ  COMP_LPCOMP_IRQHandler
+    IRQ  SWI0_EGU0_IRQHandler
+    IRQ  SWI1_EGU1_IRQHandler
+    IRQ  SWI2_EGU2_IRQHandler
+    IRQ  SWI3_EGU3_IRQHandler
+    IRQ  SWI4_EGU4_IRQHandler
+    IRQ  SWI5_EGU5_IRQHandler
+    IRQ  TIMER3_IRQHandler
+    IRQ  TIMER4_IRQHandler
+    IRQ  PWM0_IRQHandler
+    IRQ  PDM_IRQHandler
+    IRQ  MWU_IRQHandler
+    IRQ  PWM1_IRQHandler
+    IRQ  PWM2_IRQHandler
+    IRQ  SPIM2_SPIS2_SPI2_IRQHandler
+    IRQ  RTC2_IRQHandler
+    IRQ  I2S_IRQHandler
+    IRQ  FPU_IRQHandler
+
+  .end


### PR DESCRIPTION
This PR will add support to compile for nRF52 using this "ancient" repo. This way you can create an app targeting SDK 11 (and probably even SDK 12) that can be compiled for both nRF51 and nRF52 using the same codebase. If you use the "simple_ble" library you can just target to SDK 11 and the same codebase will compile. However if you want to use the SDK 12 you will need to do some modifications since the SoftDevice for nRF52 and nRF51 are not quite the same (v3.0.0 vs v2.0.1).

The "full_adv" example has been tweaked to support compilation for both platforms.

This should fix the issue #44.