### PR TITLE
BLE_UUID_VS_COUNT_DEFAULT does not work on nRF51 platform

### DIFF
--- a/lib/simple_ble.c
+++ b/lib/simple_ble.c
@@ -407,7 +407,7 @@ void __attribute__((weak)) ble_stack_init (void) {
     err_code = softdevice_enable_get_default_config(CENTRAL_LINK_COUNT, // central link count
                                                     PERIPHERAL_LINK_COUNT, // peripheral link count
                                                     &ble_enable_params);
-    ble_enable_params.common_enable_params.vs_uuid_count = BLE_UUID_VS_COUNT_DEFAULT;
+    ble_enable_params.common_enable_params.vs_uuid_count = BLE_UUID_VS_COUNT_MIN;
     APP_ERROR_CHECK(err_code);
 
     //Check the ram settings against the used number of links


### PR DESCRIPTION
Somehow this is needed in order for S130 to work. However BLE_UUID_VS_COUNT_DEFAULT will work on S132, not sure why. Since more of my tests were don on nRF52 platform I didn't see this problem before my last commit.