### PR TITLE
Fixed "Error: SVC is not permitted on this architecture"

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -809,7 +809,7 @@ ifneq (,$(filter $(NRF_IC),nrf52832 nrf52833 nrf52840))
 	#CPUFLAGS = -mthumb -mabi=aapcs -mcpu=cortex-m4 -march=armv7e-m -mfloat-abi=soft -mfpu=fpv4-sp-d16
 	CPUFLAGS = -mthumb -mcpu=cortex-m4 -march=armv7e-m 
 else
-	CPUFLAGS = -mthumb -mcpu=cortex-m0 -march=armv6-m
+	CPUFLAGS = -mthumb -mcpu=cortex-m0 -march=armv6s-m
 endif
 
 CFLAGS += -std=gnu99 -c $(CPUFLAGS) -Wall -Wextra -Wno-unused-parameter -Werror=return-type -D$(DEVICE) -D$(BOARD) -D$(NRF_IC_UPPER) -DSDK_VERSION_$(SDK_VERSION) -DSOFTDEVICE_$(SOFTDEVICE_MODEL)


### PR DESCRIPTION
The error
```
Error: SVC is not permitted on this architecture
```
will appear when using newer `arm-none-eabi-gcc`. Setting `-march=armv6s-m` will fix it.